### PR TITLE
Add highlighting and scores to metadata for search results

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clucy "0.2.0"
+(defproject clucy "0.2.1-SNAPSHOT"
   :description "A Clojure interface to the Lucene search engine"
   :url "http://github/weavejester/clucy"
   :dependencies [[org.clojure/clojure "1.2.1"]

--- a/project.clj
+++ b/project.clj
@@ -2,4 +2,5 @@
   :description "A Clojure interface to the Lucene search engine"
   :url "http://github/weavejester/clucy"
   :dependencies [[org.clojure/clojure "1.2.1"]
-                 [org.apache.lucene/lucene-core "3.0.3"]])
+                 [org.apache.lucene/lucene-core "3.0.3"]
+                 [org.apache.lucene/lucene-highlighter "3.0.3"]])

--- a/src/clucy/core.clj
+++ b/src/clucy/core.clj
@@ -1,6 +1,7 @@
 (ns clucy.core
   (:require [clojure.java.io :as io])
   (:import java.io.File
+           java.io.StringReader
            org.apache.lucene.document.Document
            (org.apache.lucene.document Field Field$Store Field$Index)
            (org.apache.lucene.index IndexWriter IndexWriter$MaxFieldLength)
@@ -12,6 +13,9 @@
            org.apache.lucene.search.BooleanQuery
            org.apache.lucene.search.BooleanClause
            org.apache.lucene.search.BooleanClause$Occur
+           org.apache.lucene.search.highlight.QueryScorer
+           org.apache.lucene.search.highlight.Highlighter
+           org.apache.lucene.search.highlight.SimpleHTMLFormatter
            org.apache.lucene.index.Term
            org.apache.lucene.search.TermQuery))
 
@@ -147,20 +151,49 @@
                   :tokenized (.isTokenized f)}]))
         (dissoc :_content))))
 
+(defn- make-highlighter
+  "Create a highlighter function which will take a map and return the map with
+highlighted results appended. Highlighting is configured by passing the config
+map."
+  [query searcher config]
+  (if config
+    (let [indexReader (.getIndexReader searcher)
+          scorer (QueryScorer. (.rewrite query indexReader))
+          config (merge {:max-fragments 5
+                         :separator "..."
+                         :fragments-key :fragments
+                         :pre "<b>"
+                         :post "</b>"}
+                        config)
+          {:keys [field max-fragments separator fragments-key pre post]} config
+          highlighter (Highlighter. (SimpleHTMLFormatter. pre post) scorer)]
+      (fn [m]
+        (let [str (field m)
+              token-stream (.tokenStream *analyzer*
+                                         (name field)
+                                         (StringReader. str))
+              best-fragments (.getBestFragments highlighter
+                                                token-stream
+                                                str
+                                                max-fragments
+                                                separator)]
+          (assoc m fragments-key best-fragments))))
+    identity))
+
 (defn search
   "Search the supplied index with a query string."
-  ([index query max-results]
-     (if *content*
-       (search index query max-results :_content)
-       (throw (Exception. "No default search field specified"))))
-  ([index query max-results default-field]
-    (with-open [searcher (IndexSearcher. (:index @index))]
-      (let [parser (QueryParser. *version* (as-str default-field) *analyzer*)
-            query  (.parse parser query)
-            hits   (.search searcher query max-results)]
-        (doall
-          (for [hit (.scoreDocs hits)]
-            (document->map (.doc searcher (.doc hit)))))))))
+  [index query max-results & {:keys [highlight default-field]}]
+  (if (every? false? [default-field *content*])
+    (throw (Exception. "No default search field specified"))
+    (let [default-field (or default-field :_content)]
+      (with-open [searcher (IndexSearcher. (:index @index))]
+        (let [parser (QueryParser. *version* (as-str default-field) *analyzer*)
+              query  (.parse parser query)
+              hits   (.search searcher query max-results)
+              highlighter (make-highlighter query searcher highlight)]
+          (doall
+           (for [hit (.scoreDocs hits)]
+             (highlighter (document->map (.doc searcher (.doc hit)))))))))))
 
 (defn search-and-delete
   "Search the supplied index with a query string and then delete all

--- a/src/clucy/core.clj
+++ b/src/clucy/core.clj
@@ -143,7 +143,7 @@
      (let [m (-> (into {}
                    (for [f (.getFields document)]
                      [(keyword (.name f)) (.stringValue f)])))
-           fragments (highlighter m)
+           fragments (highlighter m) ; so that we can highlight :_content
            m (dissoc m :_content)]
        (with-meta
          m

--- a/test/clucy/test/core.clj
+++ b/test/clucy/test/core.clj
@@ -39,4 +39,14 @@
     (let [index (memory-index)]
       (doseq [person people] (add index person))
       (search-and-delete index "name:mary")
-      (is (== 0 (count (search index "name:mary" 10)))))))
+      (is (== 0 (count (search index "name:mary" 10))))))
+
+  (testing "search fn with highlighting"
+    (let [index (memory-index)
+          config {:field :name
+                  :max-fragments 5
+                  :separator "..."
+                  :fragments-key :best}]
+      (doseq [person people] (add index person))
+      (is (= (map :best (search index "name:mary" 10 :highlight config))
+             ["<b>Mary</b>" "<b>Mary</b> Lou"])))))

--- a/test/clucy/test/core.clj
+++ b/test/clucy/test/core.clj
@@ -43,10 +43,14 @@
 
   (testing "search fn with highlighting"
     (let [index (memory-index)
-          config {:field :name
-                  :max-fragments 5
-                  :separator "..."
-                  :fragments-key :best}]
+          config {:field :name}]
       (doseq [person people] (add index person))
-      (is (= (map :best (search index "name:mary" 10 :highlight config))
-             ["<b>Mary</b>" "<b>Mary</b> Lou"])))))
+      (is (= (map #(-> % meta :_fragments)
+                  (search index "name:mary" 10 :highlight config))
+             ["<b>Mary</b>" "<b>Mary</b> Lou"]))))
+
+    (testing "search fn returns scores in metadata"
+    (let [index (memory-index)]
+      (doseq [person people] (add index person))
+      (is (true? (every? #(> % 0) (map #(-> % meta :_score)
+                                      (search index "name:mary" 10))))))))


### PR DESCRIPTION
James,

Here are a couple of modifications that I need in order to use clucy. The changes allow highlighted fragments and scores to be included in the metadata of search results. Scores will always be included. Highlighting is optional and depends on passing a :highlight option to search. Because I added this extra optional parameter to search, I changed the two arity implementation into a function that takes three arguments and then two possible options: :highlight and :default-field.

I am still working on this and may make other changes but wanted to let you know now so that if you have any suggestions for changes I can make them while I am working on it.

Thanks James,
Brenton
