### PR TITLE
Update to Lucene 3.5.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :dependencies [[org.clojure/clojure "1.3.0"]
                  [org.apache.lucene/lucene-core "3.0.3"]
                  [org.apache.lucene/lucene-highlighter "3.0.3"]]
-  :dev-dependencies [[lein-multi "1.0.0"]]
+  :dev-dependencies [[lein-multi "1.1.0"]]
   :multi-deps {"lucene2" [[org.clojure/clojure "1.2.1"]
                           [org.apache.lucene/lucene-core "2.9.2"]
                           [org.apache.lucene/lucene-highlighter "2.9.2"]]})

--- a/project.clj
+++ b/project.clj
@@ -5,6 +5,12 @@
                  [org.apache.lucene/lucene-core "3.0.3"]
                  [org.apache.lucene/lucene-highlighter "3.0.3"]]
   :dev-dependencies [[lein-multi "1.1.0"]]
-  :multi-deps {"lucene2" [[org.clojure/clojure "1.2.1"]
-                          [org.apache.lucene/lucene-core "2.9.2"]
-                          [org.apache.lucene/lucene-highlighter "2.9.2"]]})
+  :multi-deps {"1.2-lucene2" [[org.clojure/clojure "1.2.1"]
+                              [org.apache.lucene/lucene-core "2.9.2"]
+                              [org.apache.lucene/lucene-highlighter "2.9.2"]]
+               "1.3-lucene2" [[org.clojure/clojure "1.3.0"]
+                              [org.apache.lucene/lucene-core "2.9.2"]
+                              [org.apache.lucene/lucene-highlighter "2.9.2"]]
+               "1.2-lucene3" [[org.clojure/clojure "1.2.1"]
+                              [org.apache.lucene/lucene-core "3.0.3"]
+                              [org.apache.lucene/lucene-highlighter "3.0.3"]]})

--- a/project.clj
+++ b/project.clj
@@ -2,8 +2,8 @@
   :description "A Clojure interface to the Lucene search engine"
   :url "http://github/weavejester/clucy"
   :dependencies [[org.clojure/clojure "1.3.0"]
-                 [org.apache.lucene/lucene-core "3.0.3"]
-                 [org.apache.lucene/lucene-highlighter "3.0.3"]]
+                 [org.apache.lucene/lucene-core "3.5.0"]
+                 [org.apache.lucene/lucene-highlighter "3.5.0"]]
   :dev-dependencies [[lein-multi "1.1.0"]]
   :multi-deps {"1.2-lucene2" [[org.clojure/clojure "1.2.1"]
                               [org.apache.lucene/lucene-core "2.9.2"]
@@ -12,5 +12,5 @@
                               [org.apache.lucene/lucene-core "2.9.2"]
                               [org.apache.lucene/lucene-highlighter "2.9.2"]]
                "1.2-lucene3" [[org.clojure/clojure "1.2.1"]
-                              [org.apache.lucene/lucene-core "3.0.3"]
-                              [org.apache.lucene/lucene-highlighter "3.0.3"]]})
+                              [org.apache.lucene/lucene-core "3.5.0"]
+                              [org.apache.lucene/lucene-highlighter "3.5.0"]]})


### PR DESCRIPTION
Hi,

the three commits essentially upgrades clucy to use Lucene 3.5.0. The most intrusive change is that the index is no longer a struct, but the actual index object. This is due to a change in Lucene 3.5.0 in that index optimization calls are discouraged. See [LUCENE-3454](https://issues.apache.org/jira/browse/LUCENE-3454) for a discussion of this change, which has been summarised in the release notes as:

  "Renamed IndexWriter.optimize to forceMerge to discourage use of this method since it is horribly 
    costly and rarely justified anymore."

The index can still be manually "optimized" by calling forceMerge directly, which should probably be documented in the README. It might even make sense to introduce a wrapper function force-merge [index max-segments] around [IndexWriter.forceMerge](http://lucene.apache.org/core/old_versioned_docs/versions/3_5_0/api/all/org/apache/lucene/index/IndexWriter.html#forceMerge%28int%29), but I haven't done that yet.

Thank you and may you have a nice day!
