### PR TITLE
default-operator support for search function

### DIFF
--- a/test/clucy/test/core.clj
+++ b/test/clucy/test/core.clj
@@ -33,7 +33,10 @@
   (testing "search fn"
     (let [index (memory-index)]
       (doseq [person people] (add index person))
-      (is (== 1 (count (search index "name:miles" 10))))))
+      (is (== 1 (count (search index "name:miles" 10))))
+      (is (== 1 (count (search index "name:miles age:100" 10))))
+      (is (== 0 (count (search index "name:miles AND age:100" 10))))
+      (is (== 0 (count (search index "name:miles age:100" 10 :default-operator :and))))))
 
   (testing "search-and-delete fn"
     (let [index (memory-index)]


### PR DESCRIPTION
Hi,

A project I'm working on needs be able to change the default operator to an AND.

I've added an extra keyword argument and some tests to support setting the default operator on the QueryParser.

If :default-operator is not supplied then the default of OR is used, if it is supplied then it must be either :and or :or otherwise it'll cause problems for the case statement.

I've found clucy very useful, thanks.

-- sim
