### PR TITLE
Upgrade to Lucene 4.2.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,18 +1,17 @@
 (defproject clucy "0.3.0"
   :description "A Clojure interface to the Lucene search engine"
   :url "http://github/weavejester/clucy"
-  :dependencies [[org.clojure/clojure "1.3.0"]
-                 [org.apache.lucene/lucene-core "3.5.0"]
-                 [org.apache.lucene/lucene-highlighter "3.5.0"]]
+  :dependencies [[org.clojure/clojure "1.4.0"]
+                 [org.apache.lucene/lucene-core "4.2.0"]
+                 [org.apache.lucene/lucene-queryparser "4.2.0"]
+                 [org.apache.lucene/lucene-analyzers-common "4.2.0"]
+                 [org.apache.lucene/lucene-highlighter "4.2.0"]]
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dev-dependencies [[lein-multi "1.1.0"]]
-  :multi-deps {"1.2-lucene2" [[org.clojure/clojure "1.2.1"]
-                              [org.apache.lucene/lucene-core "2.9.2"]
-                              [org.apache.lucene/lucene-highlighter "2.9.2"]]
-               "1.3-lucene2" [[org.clojure/clojure "1.3.0"]
-                              [org.apache.lucene/lucene-core "2.9.2"]
-                              [org.apache.lucene/lucene-highlighter "2.9.2"]]
-               "1.2-lucene3" [[org.clojure/clojure "1.2.1"]
-                              [org.apache.lucene/lucene-core "3.5.0"]
-                              [org.apache.lucene/lucene-highlighter "3.5.0"]]})
+  :profiles {:1.4  {:dependencies [[org.clojure/clojure "1.4.0"]]}
+             :1.5  {:dependencies [[org.clojure/clojure "1.5.0"]]}
+             :1.6  {:dependencies [[org.clojure/clojure "1.6.0-master-SNAPSHOT"]]}}
+  :codox {:src-dir-uri "http://github/weavejester/clucy/blob/master"
+          :src-linenum-anchor-prefix "L"}
+  ;; :warn-on-reflection true
+  )


### PR DESCRIPTION
Hi, 

I ported clucy to lucene 4.2.0. There are a couple of API/library changes, some have been moved to separate packages, and some classes had their name changed. There was also the introduction of IndexReader that forced me to change the code in `search`. 
I also killed the reflections in the process, this helped me figure out what to update and it's (probably) welcomed anyway. 

I had to remove multideps since the api changed too much to allow to keep backward compatibility and added a basic travis file that "should" just work. 

The tests still pass (without any modification), and everything seems to be working. 

Max
