### PR TITLE
Expose sort and custom queries (instead of using QueryParser)

### DIFF
--- a/test/clucy/test/core.clj
+++ b/test/clucy/test/core.clj
@@ -69,4 +69,23 @@
       (is (== 1 (count (search index "m*" 10 :page 1 :results-per-page 3))))
       (is (empty? (intersection
                     (set (search index "m*" 10 :page 0 :results-per-page 3))
-                    (set (search index "m*" 10 :page 1 :results-per-page 3))))))))
+                    (set (search index "m*" 10 :page 1 :results-per-page 3)))))))
+  
+  (testing "sorting by name"
+    (let [index (memory-index)
+          _ (doseq [person people] (add index person))
+          results (search index "m*" 10 :sort (create-sort "name"))]
+      (is (= "Mary" (:name (first results))))
+      (is (= "Miles" (:name (last results))))))
+  
+  (testing "sorting by age"
+    (let [index (memory-index)]
+      (doseq [person people] (add index person))
+      (is (= "Melinda" (:name (first (search index "m*" 10 :sort (create-sort "age" :type :float))))))
+      (is (= "Mary" (:name (last (search index "m*" 10 :sort (create-sort "age" :type :float))))))))
+  
+  (testing "reverse sorting by age"
+    (let [index (memory-index)]
+      (doseq [person people] (add index person))
+      (is (= "Mary" (:name (first (search index "m*" 10 :sort (create-sort "age" :type :float :reverse? true))))))
+      (is (= "Melinda" (:name (last (search index "m*" 10 :sort (create-sort "age" :type :float :reverse? true)))))))))


### PR DESCRIPTION
This commit introduces two new features:

1) It is possible to pass a sort to the search function to have the output sorted. A utility function for creating the most common sorts is provided but it is also possible to create a sort manually and pass it to search.

2) It is possible to pass the search function an instantiated query rather than a string to bypass the query parser. Passing a string works as expected.
