### PR TITLE
Update to Lucene 4.10.4

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clucy "0.4.1"
+(defproject me.arrdem/clucy "0.4.1"
   :description "A Clojure interface to the Lucene search engine"
   :url "http://github/weavejester/clucy"
   :dependencies [[org.clojure/clojure "1.4.0"]

--- a/project.clj
+++ b/project.clj
@@ -1,15 +1,16 @@
-(defproject clucy "0.4.0"
+(defproject clucy "0.4.1"
   :description "A Clojure interface to the Lucene search engine"
   :url "http://github/weavejester/clucy"
   :dependencies [[org.clojure/clojure "1.4.0"]
-                 [org.apache.lucene/lucene-core "4.2.0"]
-                 [org.apache.lucene/lucene-queryparser "4.2.0"]
-                 [org.apache.lucene/lucene-analyzers-common "4.2.0"]
-                 [org.apache.lucene/lucene-highlighter "4.2.0"]]
+                 [org.apache.lucene/lucene-core "4.10.4"]
+                 [org.apache.lucene/lucene-queryparser "4.10.4"]
+                 [org.apache.lucene/lucene-analyzers-common "4.10.4"]
+                 [org.apache.lucene/lucene-highlighter "4.10.4"]]
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :profiles {:1.4  {:dependencies [[org.clojure/clojure "1.4.0"]]}
              :1.5  {:dependencies [[org.clojure/clojure "1.5.0"]]}
-             :1.6  {:dependencies [[org.clojure/clojure "1.6.0-master-SNAPSHOT"]]}}
+             :1.6  {:dependencies [[org.clojure/clojure "1.6.0"]]}
+             :1.7  {:dependencies [[org.clojure/clojure "1.7.0"]]}}
   :codox {:src-dir-uri "http://github/weavejester/clucy/blob/master"
           :src-linenum-anchor-prefix "L"})

--- a/src/clucy/core.clj
+++ b/src/clucy/core.clj
@@ -114,7 +114,7 @@
   (with-open [^IndexWriter writer (index-writer index)]
     (doseq [m maps]
       (let [^BooleanQuery query (BooleanQuery.)
-            #^"[Lorg.apache.lucene.search.Query;" arr (into-array BooleanQuery [query])]
+            ^"[Lorg.apache.lucene.search.Query;" arr (into-array BooleanQuery [query])]
         (doseq [[key value] m]
           (.add query
                 (BooleanClause.
@@ -214,5 +214,5 @@ fragments."
    (with-open [writer (index-writer index)]
      (let [parser (QueryParser. *version* (as-str default-field) *analyzer*)
            query  (.parse parser query)
-           #^"[Lorg.apache.lucene.search.Query;" arr (into-array [query])]
+           ^"[Lorg.apache.lucene.search.Query;" arr (into-array [query])]
        (.deleteDocuments ^IndexWriter writer arr)))))


### PR DESCRIPTION
The Lucene API changed so that `IndexWriter.deleteDocuments` became variadic. This is a non-issue for Java code since javac will upgrade transparently, but requires some reflection and array work from us. This patch makes the appropriate reflection changes to support the latest 4.X and bumps the patch number.

Porting to 5.X looks like it will be nontrivial.
